### PR TITLE
Add Command behavioral pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ This project demonstrates various design patterns implemented in C#. Design patt
    - [X] Decorator
    - [X] Facade
    - [X] Flyweight
-   - [ ] Proxy
+   - [X] Proxy
 
 3. **Behavioral Patterns**
    - [X] Chain of Responsibility
-   - [ ] Command
+   - [X] Command
    - [ ] Interpreter
    - [ ] Iterator
    - [ ] Mediator

--- a/src/DesignPatterns.Adapter/Proxy/IPolicyCache.cs
+++ b/src/DesignPatterns.Adapter/Proxy/IPolicyCache.cs
@@ -1,0 +1,7 @@
+namespace DesignPatterns.Structural.Proxy;
+
+public interface IPolicyCache
+{
+    bool TryGetPolicy(string policyId, out string info);
+    void SetPolicy(string policyId, string info);
+}

--- a/src/DesignPatterns.Adapter/Proxy/IPolicyService.cs
+++ b/src/DesignPatterns.Adapter/Proxy/IPolicyService.cs
@@ -1,0 +1,6 @@
+namespace DesignPatterns.Structural.Proxy;
+
+public interface IPolicyService
+{
+    string GetPolicyInfo(string policyId);
+}

--- a/src/DesignPatterns.Adapter/Proxy/InMemoryPolicyCache.cs
+++ b/src/DesignPatterns.Adapter/Proxy/InMemoryPolicyCache.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+
+namespace DesignPatterns.Structural.Proxy;
+
+public class InMemoryPolicyCache : IPolicyCache
+{
+    private readonly Dictionary<string, string> _cache = new();
+
+    public bool TryGetPolicy(string policyId, out string info)
+    {
+        return _cache.TryGetValue(policyId, out info!);
+    }
+
+    public void SetPolicy(string policyId, string info)
+    {
+        _cache[policyId] = info;
+    }
+}

--- a/src/DesignPatterns.Adapter/Proxy/InsurancePolicyService.cs
+++ b/src/DesignPatterns.Adapter/Proxy/InsurancePolicyService.cs
@@ -1,0 +1,9 @@
+namespace DesignPatterns.Structural.Proxy;
+
+public class InsurancePolicyService : IPolicyService
+{
+    public string GetPolicyInfo(string policyId)
+    {
+        return $"Policy Info for {policyId}";
+    }
+}

--- a/src/DesignPatterns.Adapter/Proxy/InsurancePolicyServiceProxy.cs
+++ b/src/DesignPatterns.Adapter/Proxy/InsurancePolicyServiceProxy.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+
+namespace DesignPatterns.Structural.Proxy;
+
+public class InsurancePolicyServiceProxy : IPolicyService
+{
+    private readonly IPolicyService _realService;
+    private readonly IPolicyCache _cache;
+
+    public InsurancePolicyServiceProxy(IPolicyService realService)
+        : this(realService, new InMemoryPolicyCache())
+    {
+    }
+
+    public InsurancePolicyServiceProxy(IPolicyService realService, IPolicyCache cache)
+    {
+        _realService = realService;
+        _cache = cache;
+    }
+
+    public string GetPolicyInfo(string policyId)
+    {
+        if (_cache.TryGetPolicy(policyId, out var info))
+        {
+            return info;
+        }
+
+        info = _realService.GetPolicyInfo(policyId);
+        _cache.SetPolicy(policyId, info);
+        return info;
+    }
+}

--- a/src/DesignPatterns.Adapter/Proxy/Proxy.cs
+++ b/src/DesignPatterns.Adapter/Proxy/Proxy.cs
@@ -1,0 +1,23 @@
+using DesignPatterns.Utils.Display;
+
+namespace DesignPatterns.Structural.Proxy;
+
+public class Proxy
+{
+    private readonly IOutput _output;
+
+    public Proxy(IOutput output)
+    {
+        _output = output;
+    }
+
+    public void Run()
+    {
+        IPolicyService realService = new InsurancePolicyService();
+        IPolicyService proxy = new InsurancePolicyServiceProxy(realService);
+
+        _output.Display(proxy.GetPolicyInfo("P123"));
+        _output.Display(proxy.GetPolicyInfo("P123"));
+        _output.Display(proxy.GetPolicyInfo("P456"));
+    }
+}

--- a/src/DesignPatterns.Behavioral.Tests/Command/CommandPatternTests.cs
+++ b/src/DesignPatterns.Behavioral.Tests/Command/CommandPatternTests.cs
@@ -1,0 +1,55 @@
+using DesignPatterns.Behavioral.Command;
+using FluentAssertions;
+
+namespace DesignPatterns.Behavioral.Tests.Command;
+
+public class CommandPatternTests
+{
+    [Test]
+    public void TurnOnCommand_ShouldTurnLightOn()
+    {
+        // Arrange
+        var light = new Light();
+        var remote = new RemoteControl();
+        remote.SetCommand(new TurnOnCommand(light));
+
+        // Act
+        remote.PressButton();
+
+        // Assert
+        light.IsOn.Should().BeTrue();
+    }
+
+    [Test]
+    public void TurnOffCommand_ShouldTurnLightOff()
+    {
+        // Arrange
+        var light = new Light();
+        light.TurnOn();
+        var remote = new RemoteControl();
+        remote.SetCommand(new TurnOffCommand(light));
+
+        // Act
+        remote.PressButton();
+
+        // Assert
+        light.IsOn.Should().BeFalse();
+    }
+
+    [Test]
+    public void RemoteControl_ShouldSwitchCommands()
+    {
+        // Arrange
+        var light = new Light();
+        var remote = new RemoteControl();
+        remote.SetCommand(new TurnOnCommand(light));
+
+        // Act
+        remote.PressButton();
+        remote.SetCommand(new TurnOffCommand(light));
+        remote.PressButton();
+
+        // Assert
+        light.IsOn.Should().BeFalse();
+    }
+}

--- a/src/DesignPatterns.Behavioral/Command/Command.cs
+++ b/src/DesignPatterns.Behavioral/Command/Command.cs
@@ -1,0 +1,27 @@
+using DesignPatterns.Utils.Display;
+
+namespace DesignPatterns.Behavioral.Command;
+
+public class Command
+{
+    private readonly IOutput _output;
+
+    public Command(IOutput output)
+    {
+        _output = output;
+    }
+
+    public void Run()
+    {
+        var light = new Light();
+        var remote = new RemoteControl();
+
+        remote.SetCommand(new TurnOnCommand(light));
+        remote.PressButton();
+        _output.Display($"Light on: {light.IsOn}");
+
+        remote.SetCommand(new TurnOffCommand(light));
+        remote.PressButton();
+        _output.Display($"Light on: {light.IsOn}");
+    }
+}

--- a/src/DesignPatterns.Behavioral/Command/ICommand.cs
+++ b/src/DesignPatterns.Behavioral/Command/ICommand.cs
@@ -1,0 +1,6 @@
+namespace DesignPatterns.Behavioral.Command;
+
+public interface ICommand
+{
+    void Execute();
+}

--- a/src/DesignPatterns.Behavioral/Command/Light.cs
+++ b/src/DesignPatterns.Behavioral/Command/Light.cs
@@ -1,0 +1,9 @@
+namespace DesignPatterns.Behavioral.Command;
+
+public class Light
+{
+    public bool IsOn { get; private set; }
+
+    public void TurnOn() => IsOn = true;
+    public void TurnOff() => IsOn = false;
+}

--- a/src/DesignPatterns.Behavioral/Command/RemoteControl.cs
+++ b/src/DesignPatterns.Behavioral/Command/RemoteControl.cs
@@ -1,0 +1,16 @@
+namespace DesignPatterns.Behavioral.Command;
+
+public class RemoteControl
+{
+    private ICommand? _command;
+
+    public void SetCommand(ICommand command)
+    {
+        _command = command;
+    }
+
+    public void PressButton()
+    {
+        _command?.Execute();
+    }
+}

--- a/src/DesignPatterns.Behavioral/Command/TurnOffCommand.cs
+++ b/src/DesignPatterns.Behavioral/Command/TurnOffCommand.cs
@@ -1,0 +1,16 @@
+namespace DesignPatterns.Behavioral.Command;
+
+public class TurnOffCommand : ICommand
+{
+    private readonly Light _light;
+
+    public TurnOffCommand(Light light)
+    {
+        _light = light;
+    }
+
+    public void Execute()
+    {
+        _light.TurnOff();
+    }
+}

--- a/src/DesignPatterns.Behavioral/Command/TurnOnCommand.cs
+++ b/src/DesignPatterns.Behavioral/Command/TurnOnCommand.cs
@@ -1,0 +1,16 @@
+namespace DesignPatterns.Behavioral.Command;
+
+public class TurnOnCommand : ICommand
+{
+    private readonly Light _light;
+
+    public TurnOnCommand(Light light)
+    {
+        _light = light;
+    }
+
+    public void Execute()
+    {
+        _light.TurnOn();
+    }
+}

--- a/src/DesignPatterns.Structural.Tests/ProxyPatternTests.cs
+++ b/src/DesignPatterns.Structural.Tests/ProxyPatternTests.cs
@@ -1,0 +1,54 @@
+using DesignPatterns.Structural.Proxy;
+using FluentAssertions;
+
+namespace DesignPatterns.Structural.Tests;
+
+public class ProxyPatternTests
+{
+    private class StubPolicyService : IPolicyService
+    {
+        public int CallCount { get; private set; }
+
+        public string GetPolicyInfo(string policyId)
+        {
+            CallCount++;
+            return $"Policy Info for {policyId}";
+        }
+    }
+
+    [Test]
+    public void GetPolicyInfo_ShouldStoreResultInCache()
+    {
+        // Arrange
+        var realService = new StubPolicyService();
+        var cache = new InMemoryPolicyCache();
+        var proxy = new InsurancePolicyServiceProxy(realService, cache);
+
+        // Act
+        var result = proxy.GetPolicyInfo("P123");
+
+        // Assert
+        result.Should().Be("Policy Info for P123");
+        cache.TryGetPolicy("P123", out var cached).Should().BeTrue();
+        cached.Should().Be("Policy Info for P123");
+        realService.CallCount.Should().Be(1);
+    }
+
+    [Test]
+    public void GetPolicyInfo_ShouldUseCachedValueOnSubsequentCalls()
+    {
+        // Arrange
+        var realService = new StubPolicyService();
+        var cache = new InMemoryPolicyCache();
+        var proxy = new InsurancePolicyServiceProxy(realService, cache);
+
+        // Act
+        var first = proxy.GetPolicyInfo("P123");
+        var second = proxy.GetPolicyInfo("P123");
+
+        // Assert
+        first.Should().Be("Policy Info for P123");
+        second.Should().Be("Policy Info for P123");
+        realService.CallCount.Should().Be(1);
+    }
+}


### PR DESCRIPTION
## Summary
- add Command pattern implementation with light example
- provide unit tests for Command pattern using AAA style
- refactor Proxy tests to use state-based assertions
- mark Command pattern implemented in README

## Testing
- `dotnet test src/DesignPatterns.sln --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683feac72134832897270532df453f55