### PR TITLE
Implement Proxy pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This project demonstrates various design patterns implemented in C#. Design patt
    - [X] Decorator
    - [X] Facade
    - [X] Flyweight
-   - [ ] Proxy
+   - [X] Proxy
 
 3. **Behavioral Patterns**
    - [X] Chain of Responsibility

--- a/src/DesignPatterns.Adapter/Proxy/IInsuranceService.cs
+++ b/src/DesignPatterns.Adapter/Proxy/IInsuranceService.cs
@@ -1,0 +1,6 @@
+namespace DesignPatterns.Structural.Proxy;
+
+public interface IInsuranceService
+{
+    string GetPolicyDetails(string policyId);
+}

--- a/src/DesignPatterns.Adapter/Proxy/InsuranceServiceProxy.cs
+++ b/src/DesignPatterns.Adapter/Proxy/InsuranceServiceProxy.cs
@@ -1,0 +1,30 @@
+namespace DesignPatterns.Structural.Proxy;
+
+public class InsuranceServiceProxy : IInsuranceService
+{
+    private readonly RealInsuranceService _realService;
+    private readonly Dictionary<string, string> _cache = new();
+
+    public InsuranceServiceProxy() : this(new RealInsuranceService())
+    {
+    }
+
+    public InsuranceServiceProxy(RealInsuranceService realService)
+    {
+        _realService = realService;
+    }
+
+    public int RealServiceCallCount => _realService.CallCount;
+
+    public string GetPolicyDetails(string policyId)
+    {
+        if (_cache.TryGetValue(policyId, out var details))
+        {
+            return details;
+        }
+
+        details = _realService.GetPolicyDetails(policyId);
+        _cache[policyId] = details;
+        return details;
+    }
+}

--- a/src/DesignPatterns.Adapter/Proxy/Proxy.cs
+++ b/src/DesignPatterns.Adapter/Proxy/Proxy.cs
@@ -1,0 +1,24 @@
+using DesignPatterns.Utils.Display;
+
+namespace DesignPatterns.Structural.Proxy;
+
+public class Proxy
+{
+    private readonly IOutput _output;
+
+    public Proxy(IOutput output)
+    {
+        _output = output;
+    }
+
+    public void Run()
+    {
+        IInsuranceService service = new InsuranceServiceProxy();
+
+        var firstCall = service.GetPolicyDetails("P12345");
+        var secondCall = service.GetPolicyDetails("P12345");
+
+        _output.Display(firstCall);
+        _output.Display(secondCall);
+    }
+}

--- a/src/DesignPatterns.Adapter/Proxy/RealInsuranceService.cs
+++ b/src/DesignPatterns.Adapter/Proxy/RealInsuranceService.cs
@@ -1,0 +1,12 @@
+namespace DesignPatterns.Structural.Proxy;
+
+public class RealInsuranceService : IInsuranceService
+{
+    public int CallCount { get; private set; }
+
+    public string GetPolicyDetails(string policyId)
+    {
+        CallCount++;
+        return $"Policy details for {policyId}";
+    }
+}

--- a/src/DesignPatterns.Structural.Tests/ProxyPatternTests.cs
+++ b/src/DesignPatterns.Structural.Tests/ProxyPatternTests.cs
@@ -1,0 +1,30 @@
+using DesignPatterns.Structural.Proxy;
+using FluentAssertions;
+
+namespace DesignPatterns.Structural.Tests;
+
+public class ProxyPatternTests
+{
+    [Test]
+    public void ShouldReturnPolicyDetails()
+    {
+        var realService = new RealInsuranceService();
+        var proxy = new InsuranceServiceProxy(realService);
+
+        var details = proxy.GetPolicyDetails("P12345");
+
+        details.Should().Be("Policy details for P12345");
+    }
+
+    [Test]
+    public void ShouldCallRealServiceOnlyOnceForSamePolicy()
+    {
+        var realService = new RealInsuranceService();
+        var proxy = new InsuranceServiceProxy(realService);
+
+        proxy.GetPolicyDetails("P12345");
+        proxy.GetPolicyDetails("P12345");
+
+        realService.CallCount.Should().Be(1);
+    }
+}

--- a/src/DesignPatterns/Program.cs
+++ b/src/DesignPatterns/Program.cs
@@ -10,6 +10,7 @@ using DesignPatterns.Structural.Composite;
 using DesignPatterns.Structural.Decorator;
 using DesignPatterns.Structural.Facade;
 using DesignPatterns.Structural.Flyweight;
+using DesignPatterns.Structural.Proxy;
 using DesignPatterns.Utils.Display;
 using Spectre.Console;
 
@@ -39,6 +40,7 @@ var patternGroups = new Dictionary<string, Dictionary<string, Action>>
             { "Composite", RunCompositeFactory },
             { "Decorator", RunDecoratorFactory },
             { "Facade", RunFacadeFactory },
+            { "Proxy", RunProxyFactory },
         }
     },
     {
@@ -179,6 +181,11 @@ void RunChainOfResponsibilityFactory()
 void RunFacadeFactory()
 {
     RunPattern(new Facade(new ConsoleOutput()), "Please choose option:", new[] { "Start" });
+}
+
+void RunProxyFactory()
+{
+    RunPattern(new Proxy(new ConsoleOutput()), "Please choose option:", new[] { "Start" });
 }
 
 // Helper method to generalize pattern execution


### PR DESCRIPTION
## Summary
- implement Proxy pattern for structural patterns
- add usage in console app menu
- document Proxy in README
- test proxy caching behavior

## Testing
- `dotnet test src/DesignPatterns.sln`

------
https://chatgpt.com/codex/tasks/task_e_685e7e7879cc832898a0b6a4d6cfef9e